### PR TITLE
feat: disable the built-in tweening by setting the jump prop on the svelte component

### DIFF
--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -201,9 +201,13 @@ class ScrollyVideo {
    *    - easing: (progress: number) => number - A function that defines the easing curve for the transition. It takes the progress ratio (a number between 0 and 1) as an argument and returns the eased value, affecting the playback speed during the transition.
    */
   setVideoPercentage(percentage, options = {}) {
-    if (this.transitioningRaf) {
+    if (this.transitioningRaf && !options.jump) {
       // eslint-disable-next-line no-undef
       window.cancelAnimationFrame(this.transitioningRaf);
+    }
+
+    if (this.debug) {
+      console.info('setVideoPercentage', percentage, options);
     }
 
     this.videoPercentage = percentage;

--- a/src/ScrollyVideo.svelte
+++ b/src/ScrollyVideo.svelte
@@ -14,7 +14,7 @@
   $: {
     if (scrollyVideoContainer) {
       // separate out the videoPercentage prop
-      const { videoPercentage, ...restProps } = $$props;
+      const { videoPercentage, jump, ...restProps } = $$props;
 
       if (JSON.stringify(restProps) !== lastPropsString) {
         // if scrollyvideo already exists and any parameter is updated, destroy and recreate.
@@ -32,7 +32,7 @@
         videoPercentage >= 0 &&
         videoPercentage <= 1
       ) {
-        scrollyVideo.setVideoPercentage(videoPercentage);
+        scrollyVideo.setVideoPercentage(videoPercentage, {jump});
       }
     }
   }


### PR DESCRIPTION
This might not be the best idea?

Why am I doing this? Because the code for allowing easing functions is badly implemented.

Setting `jump` to true allows sidestepping all of these issues and gives me the option to use easing and tweening functions outside of the ScrollyVideo code.