### PR TITLE
feat: decode video in web worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "mp4box": "^0.4.9",
+        "rollup-plugin-web-worker-loader": "^1.7.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -3534,7 +3535,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -5026,7 +5026,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5138,6 +5137,15 @@
       },
       "peerDependencies": {
         "@vue/compiler-sfc": "*"
+      }
+    },
+    "node_modules/rollup-plugin-web-worker-loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.7.0.tgz",
+      "integrity": "sha512-msfN4FpdoTtfSCbeTZ8yPYmfi2/66Q53gQGmvOrEz/UfqZgCkSkGjaxsZt7TQ1V0s0tLJAe6HL+EdA7IBaUF6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "rollup": "^1.9.2 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -8634,7 +8642,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -9685,7 +9692,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -9765,6 +9771,12 @@
         "hash-sum": "^2.0.0",
         "rollup-pluginutils": "^2.8.2"
       }
+    },
+    "rollup-plugin-web-worker-loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.7.0.tgz",
+      "integrity": "sha512-msfN4FpdoTtfSCbeTZ8yPYmfi2/66Q53gQGmvOrEz/UfqZgCkSkGjaxsZt7TQ1V0s0tLJAe6HL+EdA7IBaUF6w==",
+      "requires": {}
     },
     "rollup-pluginutils": {
       "version": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "mp4box": "^0.4.9",
+    "rollup-plugin-web-worker-loader": "^1.7.0",
     "ua-parser-js": "^1.0.2"
   },
   "devDependencies": {
@@ -71,5 +72,6 @@
     "printWidth": 80,
     "tabWidth": 2,
     "useTabs": false
-  }
+  },
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,7 +65,9 @@ export default [
       commonjs(),
 
       //webworker support
-      webWorkerLoader(),
+      webWorkerLoader({
+        sourceMap: !production,
+      }),
 
       // If we're building for production (npm run build
       // instead of npm run dev), minify

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import livereload from 'rollup-plugin-livereload';
 import copy from 'rollup-plugin-copy';
 import { terser } from 'rollup-plugin-terser';
 import css from 'rollup-plugin-css-only';
+import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import sveltePreprocess from 'svelte-preprocess';
 import { spawn } from 'child_process';
 
@@ -17,7 +18,9 @@ const production = !watch;
 const serve = () => {
   let server;
 
-  const toExit = () => { if (server) server.kill(0); };
+  const toExit = () => {
+    if (server) server.kill(0);
+  };
 
   return {
     writeBundle() {
@@ -61,13 +64,17 @@ export default [
       resolve({ browser: true }),
       commonjs(),
 
+      //webworker support
+      webWorkerLoader(),
+
       // If we're building for production (npm run build
       // instead of npm run dev), minify
-      production && terser({
-        output: {
-          comments: false,
-        },
-      }),
+      production &&
+        terser({
+          output: {
+            comments: false,
+          },
+        }),
     ],
   },
   // The react component needs to be built
@@ -89,6 +96,7 @@ export default [
       }),
       resolve(),
       commonjs(),
+	    webWorkerLoader(),
     ],
   },
   // The vue component needs to be built
@@ -105,6 +113,7 @@ export default [
       }),
       resolve(),
       commonjs(),
+	    webWorkerLoader(),
     ],
   },
   // The config for building the scrolly-video library and the docs site,
@@ -126,7 +135,10 @@ export default [
       copy({
         targets: [
           // The public folder for development
-          { src: ['static/**/*', 'static/.nojekyll', 'README.md'], dest: 'build' },
+          {
+            src: ['static/**/*', 'static/.nojekyll', 'README.md'],
+            dest: 'build',
+          },
         ],
       }),
 
@@ -135,7 +147,7 @@ export default [
           sourceMap: !production,
         }),
         compilerOptions: {
-        // enable run-time checks when not in production
+          // enable run-time checks when not in production
           dev: !production,
         },
       }),
@@ -153,6 +165,7 @@ export default [
         dedupe: ['svelte'],
       }),
       commonjs(),
+	    webWorkerLoader(),
 
       // In dev mode, call `npm run start` once
       // the bundle has been generated
@@ -164,10 +177,12 @@ export default [
 
       // If we're building for production (npm run build
       // instead of npm run dev), minify
-      production && terser({
-        output: {
-          comments: false,
-        },
-      }),
+      production &&
+        terser({
+          output: {
+            comments: false,
+          },
+        }),
     ],
-  }].filter((d) => d);
+  },
+].filter((d) => d);

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -289,7 +289,7 @@ class ScrollyVideo {
 
       // Show the video
       this.video.style.display = 'block';
-      this.layoutContainer.style.display = 'none';
+      this.canvas.style.display = 'none';
     }
     // Update video to the latest requested frame
     // restart transition

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -158,6 +158,11 @@ class ScrollyVideo {
 
     // Add scroll listener for responding to scroll position
     this.updateScrollPercentage = (jump) => {
+      // handle cases where we get an event object instead of a boolean as a parameter
+      if (jump && typeof jump === 'object') {
+        jump = true
+      }
+
       // Used for internally setting the scroll percentage based on built-in listeners
       const containerBoundingClientRect =
         this.container.parentNode.getBoundingClientRect();
@@ -185,7 +190,7 @@ class ScrollyVideo {
     // Add our event listeners for handling changes to the window or scroll
     if (this.trackScroll) {
       // eslint-disable-next-line no-undef
-      window.addEventListener('scroll', this.updateScrollPercentage);
+      window.addEventListener('scroll', this.updateScrollPercentage, {passive: true});
 
       // Set the initial scroll percentage
       this.video.addEventListener(

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -209,15 +209,15 @@ class ScrollyVideo {
    *
    * Public entry point to directly manipulate the video position.
    *
-   * @param percentage - The percentage of the video duration to set as the current time.
-   * @param options - Configuration options for adjusting the video playback.
-   *    - jump: boolean - If true, the video currentTime will jump directly to the specified
-   *   percentage. If false, the change will be animated over time.
-   *    - transitionSpeed: number - Defines the speed of the transition when `jump` is false.
-   *   Represents the duration of the transition in milliseconds. Default is 8.
-   *    - easing: (progress: number) => number - A function that defines the easing curve for the
-   *   transition. It takes the progress ratio (a number between 0 and 1) as an argument and
-   *   returns the eased value, affecting the playback speed during the transition.
+   * @param {number} percentage  - The percentage of the video duration to set as the current time.
+   * @param {object} [options={}] - Configuration options for adjusting the video playback.
+   * @param {boolean} options.jump - If true, the video currentTime will jump directly to the
+   *   specified percentage. If false, the change will be animated over time.
+   * @param {number} options.transitionSpeed - Defines the speed of the transition when `jump` is
+   *   false. Represents the duration of the transition in milliseconds. Default is 8.
+   * @param {(progress: number) => number} options.easing - A function that defines the easing
+   *   curve for the transition. It takes the progress ratio (a number between 0 and 1) as an
+   *   argument and returns the eased value, affecting the playback speed during the transition.
    */
   setVideoPercentage(percentage, options = {}) {
     if (this.transitioningRaf) {
@@ -239,7 +239,7 @@ class ScrollyVideo {
   /**
    * Sets the style of the video or canvas to "cover" it's container
    *
-   * @param el
+   * @param {HTMLVideoElement | HTMLCanvasElement} el
    */
   setCoverStyle(el) {
     el.style.width = '100%';
@@ -368,12 +368,12 @@ class ScrollyVideo {
    * @param {Object} options - Configuration options for adjusting the video playback.
    * @param {boolean} options.jump - If true, the video currentTime will jump
    *   directly to the specified percentage. If false, the change will be animated over time.
-   * @param {number} options.transitionSpeed - Defines the speed of the transition when `jump` is false.
-   *   Represents the duration of the transition in milliseconds. Default is 8. Use 0 to use the
-   *   native speed of the video.
-   * @param {(progress: number) => number} options.easing - A function that defines the easing curve for the
-   *   transition. It takes the progress ratio (a number between 0 and 1) as an argument and
-   *   returns the eased value, affecting the playback speed during the transition.
+   * @param {number} options.transitionSpeed - Defines the speed of the transition when `jump` is
+   *   false. Represents the duration of the transition in milliseconds. Default is 8. Use 0 to use
+   *   the native speed of the video.
+   * @param {(progress: number) => number} options.easing - A function that defines the easing
+   *   curve for the transition. It takes the progress ratio (a number between 0 and 1) as an
+   *   argument and returns the eased value, affecting the playback speed during the transition.
    */
   transitionToTargetTime({
     jump,

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -278,7 +278,18 @@ class ScrollyVideo {
 
       this.canvas.style.display = 'block';
       // Hide the video
-      this.video.style.display = 'none';
+      // this.video.style.display = 'none';
+
+			// Allow inspection of individual frames
+      if (this.debug) {
+        window.videoscrollerPaintFrame = (frame) => {
+          this.decodeWorker.postMessage({
+            message: 'PAINT_FRAME',
+            frame,
+	          debug: this.debug,
+          });
+        };
+      }
     } else {
       if (this.debug) console.log('Turning canvas off; falling back to video');
       // synchronise the current time with the worker
@@ -288,7 +299,7 @@ class ScrollyVideo {
       });
 
       // Show the video
-      this.video.style.display = 'block';
+      //this.video.style.display = 'block';
       this.canvas.style.display = 'none';
     }
     // Update video to the latest requested frame
@@ -386,7 +397,7 @@ class ScrollyVideo {
             // The video has been decoded, so we can set up the canvas
             this.canvas = document.createElement('canvas');
             const offscreen = this.canvas.transferControlToOffscreen();
-            this.layoutContainer.appendChild(this.canvas);
+            this.layoutContainer.append(this.canvas);
             this.setElementExpansion(this.canvas);
             this.setCoverStyle(this.canvas);
             this.decodeWorker.postMessage(
@@ -427,6 +438,7 @@ class ScrollyVideo {
 
       // move back to video
       this.useCanvas = false;
+			this.decodeWorker.terminate();
     }
 
     this.decodeWorker.onerror = (event) => {
@@ -435,6 +447,7 @@ class ScrollyVideo {
 
       // fall back to video
       this.useCanvas = false;
+			this.decodeWorker.terminate();
     };
 
     this.onReady();
@@ -755,7 +768,7 @@ class ScrollyVideo {
   destroy() {
     if (this.debug) console.log('Destroying ScrollyVideo');
 
-    this.decodeWorker.terminate();
+		if (this.decodeWorker) this.decodeWorker.terminate();
 
     if (this.trackScroll)
       // eslint-disable-next-line no-undef

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -450,6 +450,10 @@ class ScrollyVideo {
 			this.decodeWorker.terminate();
     };
 
+    // Try to cover all the bases when a user opens another page
+    window.addEventListener('popstate', () => {this.decodeWorker.terminate();});
+    window.addEventListener('pagehide', () => {this.decodeWorker.terminate();});
+
     this.onReady();
   }
 

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -22,7 +22,7 @@ class ScrollyVideo {
     trackScroll = true, // Whether this object should automatically respond to scroll
     lockScroll = true, // Whether it ignores human scroll while it runs `setVideoPercentage` with enabled `trackScroll`
     transitionSpeed = 8, // How fast the video transitions between points
-    frameThreshold = 0.001, // When to stop the video animation, in seconds
+    frameThreshold = 0.05, // When to stop the video animation, in seconds
     useWebCodecs = true, // Whether to try using the webcodecs approach
     onReady = () => {}, // A callback that invokes on video decode
     onChange = () => {}, // A callback that invokes on video percentage change
@@ -547,7 +547,8 @@ class ScrollyVideo {
             easing(getProgressAtTimestamp(timestamp));
           const easingFactor = easedProgressDistance / progressDistance;
 
-          const desiredPlaybackRate = basePlaybackRate * easingFactor;
+					// clamp between 0.0625 - 16.0
+          const desiredPlaybackRate = Math.min(Math.max(0.0625, basePlaybackRate * easingFactor), 16);
 
           if (this.debug)
             console.info('ScrollyVideo playbackRate:', desiredPlaybackRate);

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -315,26 +315,6 @@ class ScrollyVideo {
   }
 
   /**
-   * The easing function to use when playing the video
-   * @type {(x: number) => number}
-   */
-  #easing = (x) => x;
-
-  /**
-   * @param value {(x: number) => number}
-   */
-  set easing(value) {
-    this.#easing = value;
-  }
-
-  /**
-   * @returns {function(number): number}
-   */
-  get easing() {
-    return this.#easing;
-  }
-
-  /**
    * Sets the currentTime of the video as a specified percentage of its total duration.
    *
    * Public entry point to directly manipulate the video position.

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -516,7 +516,9 @@ class ScrollyVideo {
 
         const easedProgress =
           easing && Number.isFinite(progress) ? easing(progress) : progress;
-        this.currentTime += easedProgress * directionFactor;
+
+				// Calculate desired currentTime; multiply with 0.001 since this one is in seconds
+        this.currentTime = startCurrentTime + easedProgress * duration * directionFactor * 0.001;
 
         if (this.canvas) {
           this.paintCanvasFrame(Math.floor(this.currentTime * this.frameRate));

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -27,6 +27,7 @@ class ScrollyVideo {
     onReady = () => {}, // A callback that invokes on video decode
     onChange = () => {}, // A callback that invokes on video percentage change
     debug = false, // Whether to print debug stats to the console
+    easing = (x) => x, // The easing function
   }) {
     // Make sure that we have a DOM
     if (typeof document !== 'object') {
@@ -69,6 +70,7 @@ class ScrollyVideo {
     this.onReady = onReady;
     this.onChange = onChange;
     this.debug = debug;
+    this.easing = easing;
 
     // Create the initial video object. Even if we are going to use webcodecs,
     // we start with a paused video object
@@ -202,6 +204,28 @@ class ScrollyVideo {
 
     // Calls decode video to attempt webcodecs method
     this.decodeVideo();
+  }
+
+  /**
+   * The easing function to use when playing the video
+   * @type {(x: number) => number}
+   */
+  #easing = (x) => x;
+
+	/**
+	 *
+	 * @param value {(x: number) => number}
+	 */
+  set easing(value) {
+    this.#easing = value;
+  }
+
+	/**
+	 *
+	 * @returns {function(number): number}
+	 */
+  get easing() {
+    return this.#easing;
   }
 
   /**
@@ -378,7 +402,7 @@ class ScrollyVideo {
   transitionToTargetTime({
     jump,
     transitionSpeed = this.transitionSpeed,
-    easing = (x) => x,
+    easing = this.easing,
   }) {
     if (this.debug) {
       console.table({

--- a/src/videoDecoder.js
+++ b/src/videoDecoder.js
@@ -268,11 +268,13 @@ function processVideoSrc(src, debug = false) {
         frames = [];
 
         if (debug) console.error('Decoding was not successful.', err);
+				throw err;
       });
   }
 
   // Otherwise, resolve nothing
   if (debug) console.info('WebCodecs is not available in this browser.');
+	throw new Error('WebCodecs is not available in this browser.');
 }
 
 /**
@@ -484,6 +486,13 @@ self.onmessage = (event) => {
       currentTime = passedCurrentTime;
       transitioningRaf = requestAnimationFrame(() => {
         paintCanvasFrame(Math.floor(currentTime * frameRate), debug);
+      });
+      break;
+
+    case 'PAINT_FRAME':
+      const { frame } = event.data;
+      transitioningRaf = requestAnimationFrame(() => {
+        paintCanvasFrame(frame, debug, true);
       });
       break;
 

--- a/src/videoDecoder.js
+++ b/src/videoDecoder.js
@@ -112,7 +112,7 @@ const decodeVideo = (
       // Creates a VideoDecoder instance
       const decoder = new VideoDecoder({
         output: (frame) => {
-          createImageBitmap(frame, { resizeQuality: 'high' }).then((bitmap) => {
+          createImageBitmap(frame).then((bitmap) => {
             emitFrame(bitmap);
             frame.close();
 
@@ -354,7 +354,7 @@ function transitionToTargetTime(options, debug = false) {
     // This is the base case of the recursive function
     if (
       // eslint-disable-next-line no-restricted-globals
-      isNaN(targetTime) ||
+      Number.isNaN(targetTime) ||
       // If the currentTime is already close enough to the targetTime
       Math.abs(targetTime - currentTime) < frameThreshold ||
       hasPassedThreshold
@@ -471,7 +471,7 @@ self.onmessage = (event) => {
         frameRate = frames.length / duration;
         // paint first frame to get at least something
         transitioningRaf = requestAnimationFrame(() => {
-          paintCanvasFrame(0, debug, true);
+          paintCanvasFrame(1, debug, true);
         });
       } catch (e) {
         if (debug) console.error('Setting up canvas failed.', e);
@@ -483,7 +483,7 @@ self.onmessage = (event) => {
       const { currentTime: passedCurrentTime } = event.data;
       currentTime = passedCurrentTime;
       transitioningRaf = requestAnimationFrame(() => {
-        paintCanvasFrame(Math.floor(currentTime * frameRate), debug, true);
+        paintCanvasFrame(Math.floor(currentTime * frameRate), debug);
       });
       break;
 

--- a/src/videoDecoder.js
+++ b/src/videoDecoder.js
@@ -204,7 +204,12 @@ const decodeVideo = (
  * @param debug
  * @returns {Promise<never>|Promise<void>|*}
  */
-export default (src, emitFrame, debug) => {
+export default (src, emitFrame, debug) => {};
+
+// eslint-disable-next-line no-restricted-globals
+self.onmessage = (msg) => {
+  const { src, debug } = msg.data;
+
   // If our browser supports WebCodecs natively
   if (
     typeof VideoDecoder === 'function' &&
@@ -212,14 +217,25 @@ export default (src, emitFrame, debug) => {
   ) {
     if (debug)
       console.info('WebCodecs is natively supported, using native version...');
-    return decodeVideo(src, emitFrame, {
-      VideoDecoder,
-      EncodedVideoChunk,
-      debug,
+
+    const frames = [];
+
+    decodeVideo(
+      src,
+      (frame) => {
+        frames.push(frame);
+      },
+      {
+        VideoDecoder,
+        EncodedVideoChunk,
+        debug,
+      },
+    ).then(() => {
+      if (debug) console.info('Decoding successfully.');
+      self.postMessage('Decoding Successful');
     });
   }
 
   // Otherwise, resolve nothing
   if (debug) console.info('WebCodecs is not available in this browser.');
-  return Promise.resolve();
 };


### PR DESCRIPTION
Moves the decoding of the video and the subsequent rendering to a canvas to a web worker. This way, the main thread is no longer blocked by these resource-heavy tasks, and the experience improves.

Since the task is moved to another thread, the component is ready sooner, showing the video as soon as it is loaded, and replacing it with the canvas version only ofter the frames have been extracted. The component should be interactive at all times.

Currently, easing is not yet implemented in the canvas version.