### PR TITLE
fix: vite settings for library use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 build
+.svelte-kit

--- a/.npmignore
+++ b/.npmignore
@@ -10,5 +10,9 @@ dist/*
 !dist/**/*.js
 !dist/**/*.cjs
 !dist/**/*.d.ts
+!dist/**/*.svelte
+!dist/**/*.map
+!dist/**/*.vue
+!dist/**/*.jsx
 
 rollup.config.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@humanspeak/svelte-markdown": "^0.8.1",
+        "@sveltejs/package": "^2.3.11",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vue/compiler-sfc": "^3.2.45",
@@ -1066,6 +1067,42 @@
         "acorn": "^8.9.0"
       }
     },
+    "node_modules/@sveltejs/package": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.3.11.tgz",
+      "integrity": "sha512-DSMt2U0XNAdoQBYksrmgQi5dKy7jUTVDJLiagS/iXF7AShjAmTbGJQKruBuT/FfYAWvNxfQTSjkXU8eAIjVeNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "sade": "^1.8.1",
+        "semver": "^7.5.4",
+        "svelte2tsx": "~0.7.33"
+      },
+      "bin": {
+        "svelte-package": "svelte-package.js"
+      },
+      "engines": {
+        "node": "^16.14 || >=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
+      }
+    },
+    "node_modules/@sveltejs/package/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.0.3.tgz",
@@ -1511,6 +1548,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1600,6 +1653,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3093,6 +3153,16 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3167,6 +3237,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.1",
@@ -3301,6 +3382,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -3539,6 +3631,20 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -4034,6 +4140,21 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/svelte2tsx": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.36.tgz",
+      "integrity": "sha512-nBlERuCZRwmpebC8m0vDqZ9oaKsqW8frQS2l3zwFQW1voQIkItYtHxh1F5OTZEmE0meDIH6cxU36eIOQVOxlCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
+        "typescript": "^4.9.4 || ^5.0.0"
       }
     },
     "node_modules/synckit": {
@@ -5072,6 +5193,27 @@
       "dev": true,
       "requires": {}
     },
+    "@sveltejs/package": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.3.11.tgz",
+      "integrity": "sha512-DSMt2U0XNAdoQBYksrmgQi5dKy7jUTVDJLiagS/iXF7AShjAmTbGJQKruBuT/FfYAWvNxfQTSjkXU8eAIjVeNg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "sade": "^1.8.1",
+        "semver": "^7.5.4",
+        "svelte2tsx": "~0.7.33"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
+        }
+      }
+    },
     "@sveltejs/vite-plugin-svelte": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.0.3.tgz",
@@ -5417,6 +5559,15 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "requires": {
+        "readdirp": "^4.0.1"
+      }
+    },
     "clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5481,6 +5632,12 @@
       "requires": {
         "ms": "^2.1.3"
       }
+    },
+    "dedent-js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
+      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -6559,6 +6716,15 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6608,6 +6774,16 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "object-inspect": {
       "version": "1.13.1",
@@ -6703,6 +6879,16 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "path-exists": {
@@ -6819,6 +7005,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -7163,6 +7355,16 @@
             "eslint-visitor-keys": "^4.2.0"
           }
         }
+      }
+    },
+    "svelte2tsx": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.36.tgz",
+      "integrity": "sha512-nBlERuCZRwmpebC8m0vDqZ9oaKsqW8frQS2l3zwFQW1voQIkItYtHxh1F5OTZEmE0meDIH6cxU36eIOQVOxlCw==",
+      "dev": true,
+      "requires": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
       }
     },
     "synckit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nzz/et-video-scroller",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "mp4box": "^0.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nzz/et-video-scroller",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "mp4box": "^0.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nzz/et-video-scroller",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "mp4box": "^0.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nzz/et-video-scroller",
-      "version": "1.0.0-beta.2",
+      "version": "1.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "mp4box": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A component for scroll-based (or other externally controlled) playback.",
   "type": "module",
   "main": "dist/scrolly-video.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "A component for scroll-based (or other externally controlled) playback.",
   "type": "module",
   "main": "dist/scrolly-video.js",

--- a/package.json
+++ b/package.json
@@ -12,20 +12,27 @@
       "require": "./dist/scrolly-video.cjs"
     },
     "./ScrollyVideo.svelte": {
-      "import": "./dist/svelte.js",
-      "require": "./dist/svelte.cjs"
+      "types": "./dist/ScrollyVideo.svelte.d.ts",
+      "svelte": "./dist/ScrollyVideo.svelte"
+    },
+    "./ScrollyVideo.vue.js": {
+      "import": "./dist/ScrollyVideo.vue.js",
+      "require": "./dist/ScrollyVideo.vue.cjs"
+    },
+    "./ScrollyVideo.react.js": {
+      "import": "./dist/ScrollyVideo.react.js",
+      "require": "./dist/ScrollyVideo.react.cjs"
     },
     "./ScrollyVideo.vue": {
-      "import": "./dist/vue.js",
-      "require": "./dist/vue.cjs"
+      "default": "./dist/ScrollyVideo.vue"
     },
     "./ScrollyVideo.jsx": {
-      "import": "./dist/react.js",
-      "require": "./dist/react.cjs"
+      "default": "./dist/ScrollyVideo.jsx"
     }
   },
   "scripts": {
     "dev": "vite",
+    "prebuild": "svelte-package --input src",
     "build": "vite build --mode library",
     "build-docs": "vite build",
     "postbuild": "tsc",
@@ -57,6 +64,7 @@
   },
   "devDependencies": {
     "@humanspeak/svelte-markdown": "^0.8.1",
+    "@sveltejs/package": "^2.3.11",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/compiler-sfc": "^3.2.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "A component for scroll-based (or other externally controlled) playback.",
   "type": "module",
   "main": "dist/scrolly-video.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/et-video-scroller",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "A component for scroll-based (or other externally controlled) playback.",
   "type": "module",
   "main": "dist/scrolly-video.js",

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -1,5 +1,6 @@
 import UAParser from 'ua-parser-js';
 import { debounce, isScrollPositionAtTarget } from './utils';
+import DecodeWorker from './videoDecoder.js?worker&inline'
 
 /**
  *   ____                 _ _     __     ___     _
@@ -230,7 +231,7 @@ class ScrollyVideo {
 
     // Calls decode video to attempt webcodecs method
     if (window.Worker) {
-      this.decodeWorker = new Worker(new URL('./videoDecoder.js', import.meta.url), {type: 'module'})
+      this.decodeWorker = new DecodeWorker()
       this.decodeVideo();
     } else {
       this.useCanvas = false;

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -1,6 +1,5 @@
 import UAParser from 'ua-parser-js';
 import { debounce, isScrollPositionAtTarget } from './utils';
-import DecodeWorker from './videoDecoder.js?worker&inline'
 
 /**
  *   ____                 _ _     __     ___     _
@@ -231,7 +230,7 @@ class ScrollyVideo {
 
     // Calls decode video to attempt webcodecs method
     if (window.Worker) {
-      this.decodeWorker = new DecodeWorker()
+      this.decodeWorker = new Worker(new URL('./videoDecoder.js', import.meta.url), {type: 'module'})
       this.decodeVideo();
     } else {
       this.useCanvas = false;

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,15 +25,15 @@ const libraryBuild = {
   lib: {
     entry: {
       'scrolly-video': resolve(__dirname, 'src/ScrollyVideo.js'),
-      svelte: resolve(__dirname, 'src/ScrollyVideo.svelte'),
-      react: resolve(__dirname, 'src/ScrollyVideo.jsx'),
-      vue: resolve(__dirname, 'src/ScrollyVideo.vue'),
+      'ScrollyVideo.react': resolve(__dirname, 'src/ScrollyVideo.jsx'),
+      'ScrollyVideo.vue': resolve(__dirname, 'src/ScrollyVideo.vue'),
     },
     name: 'ScrollyVideo',
   },
   rollupOptions: {
     external: ['svelte', 'vue', 'mp4boxjs', 'react', 'ua-parser-js'],
   },
+  emptyOutDir: false,
 };
 
 /**


### PR DESCRIPTION
This will output a bundled version of ScrollyVideo.js, which then can be used in your own Svelte component.

The packed Svelte component does not work correctly.

My current problem is that I would like the generic ScrollyVideo.js to be bundled, and used in an otherwise un-processed version of the Svelte component – which is something I haven't figured out yet how to do.